### PR TITLE
Test merging staging to main with an extra commit

### DIFF
--- a/.github/workflows/branch-enforcer.yaml
+++ b/.github/workflows/branch-enforcer.yaml
@@ -1,0 +1,14 @@
+name: 'Check Branch is Staging'
+
+on:
+  pull_request:
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.base_ref == 'main' && github.head_ref != 'staging'
+        run: |
+          echo "ERROR: You can only merge to main from staging."
+          exit 1

--- a/message2.txt
+++ b/message2.txt
@@ -1,4 +1,4 @@
-afds
+sdfksdfjklsdfjlkafds
 adiaacsfesdfsdfow there is a new message
 
 and another line!


### PR DESCRIPTION
This is an example of trying to merge staging to a main branch that has an extra commit on it.

This shows how only checking for "mergeability" does not mean that the histories between staging and main would be synced.

I used the same command currently in the digip-umbrella, and it reports that the changes are mergeable (which, they indeed are). However, we have an entire commit on main not in staging and that should still be a red flag for our automation since we want staging to always be ahead of or equal to main.

```
$ gh pr view 23 --json mergeable --jq '.mergeable'
MERGEABLE
```


This case of an extra commit could be captured using `git rev-list --count origin/staging..origin/main-extra-commit`

```
# Get the count of commits on main-extra-commit branch not on staging branch
$ git rev-list --count origin/staging..origin/main-extra-commit
1

# Display hashes for commit(s) on main-extra-commit branch not on staging branch
$ git rev-list origin/staging..origin/main-extra-commit        
5a699dbd194e81ee351b7f5febcdf72cc07f0fc0
```
For the automated workflow to proceed, the count should be 0. New commits should only be on staging in order for the workflow to proceed.

An alternative way to write the command is:
```
# This reads as "get commits reachable from origin/main-extra-commit, but not from origin/staging"
$ git rev-list origin/main-extra-commit ^origin/staging
5a699dbd194e81ee351b7f5febcdf72cc07f0fc0
```